### PR TITLE
Prevent submenu-toggle click from following through to link.

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -41,8 +41,9 @@
 				.children('a').append('<span class="' + mo.toggleSubmenuClass + '"></span>');
 
 			// Catch click events on submenu toggle handlers.
-			menu.el.on('click', '.' + mo.toggleSubmenuClass, function() {
+			menu.el.on('click', '.' + mo.toggleSubmenuClass, function( e ) {
 				if ( menu.el.hasClass( mo.mobileClass ) ) {
+					e.preventDefault();
 					menu.toggleSubmenu( this );
 				}
 			});


### PR DESCRIPTION
On a mobile device clicking a submenu toggle link takes you to the submenu parent's url - this commit prevents that.
