### PR TITLE
On hover, prevent rightmost submenus from leaving the viewport

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -50,7 +50,7 @@
 
 			menu.el.on('hover', '.' + mo.hasSubmenuClass, function() {
 				var mo = menu.options,
-					parentmenu = $(this).closest('.' + mo.hasSubmenuClass),
+					parentmenu = $(this),
 					submenu = parentmenu.children('ul');
 			
 				if ( !menu.el.hasClass( mo.mobileClass ) ) {


### PR DESCRIPTION
I was playing around having the menu aligned to the right in a theme I was working on. I noticed that a "wide" sub-menus would leave the viewport. ("wide" here means wider than its parent + parent's distance from right edge of the screen). 

I don't have a public demo of this bug yet, but attached is the fix (which works for me). Basically if the position of the right-edge of the submenu is off-screen, it adjust the `left` attribute (normally 0) to correct it. 

This only fixes this for menus with two-layers. A third layer may still disappear off the viewport. As far as I can tell this patch doesn't break anything new.
