### PR TITLE
Add support for opening submenus when parent has focus

### DIFF
--- a/js/mo.js
+++ b/js/mo.js
@@ -76,7 +76,7 @@
 				}
 			});
 
-			menu.el.find('> li > a').focus(function(){
+			menu.el.find('li > a').focus(function(){
 				var mo = menu.options;
 				$('.thmfdn-menu-container').find('.'+mo.hasSubmenuClass ).removeClass( mo.openSubmenuClass );
 				$(this).parents('.'+mo.hasSubmenuClass ).addClass( mo.openSubmenuClass );


### PR DESCRIPTION
As mentioned in an e-mail a while back, I modified the menu to be keyboard accessible.

It works for 1-3 levels (not tried deeper). I'm not sure if it's the best method, but does seem to work pretty well. It works by finding all its parents and giving them the `openSubmenuClass` class, which is used by to toggle visibility of the submenus when viewed on a mobile device.
