### PR TITLE
Improved keyboard support

### DIFF
--- a/js/mo.js
+++ b/js/mo.js
@@ -76,10 +76,9 @@
 				}
 			});
 
-			menu.el.find('li > a').focus(function(){
+			menu.el.find('li > a').on( 'focus blur', function(){
 				var mo = menu.options;
-				$('.thmfdn-menu-container').find('.'+mo.hasSubmenuClass ).removeClass( mo.openSubmenuClass );
-				$(this).parents('.'+mo.hasSubmenuClass ).addClass( mo.openSubmenuClass );
+				$(this).parents( '.'+mo.hasSubmenuClass ).toggleClass( mo.openSubmenuClass );
 			});
 
 


### PR DESCRIPTION
As you mentioned in an e-mail, when focus goes from sub-menu to a non-menu link, there is nothing to remove the `openSubmenuClass` class. This patch fixes that by listening to both the `focus` and `blur` events.
